### PR TITLE
Single upload for small files only

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
@@ -164,10 +165,16 @@ public class S3OutputStream extends PositionOutputStream {
 
     try {
       compressionType.finalize(compressionFilter);
-      if (buffer.hasRemaining()) {
+      if (multiPartUpload == null && buffer.hasRemaining()) {
+        PutObjectRequest req = new PutObjectRequest(bucket, key,
+                new ByteArrayInputStream(buffer.array(), 0, buffer.position()), newObjectMetadata())
+                .withSSECustomerKey(sseCustomerKey)
+                .withCannedAcl(cannedAcl);
+        handleAmazonExceptions(() -> s3.putObject(req));
+      } else if (buffer.hasRemaining()) {
         uploadPart(buffer.position());
+        multiPartUpload.complete();
       }
-      multiPartUpload.complete();
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
       log.error(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -166,8 +166,10 @@ public class S3OutputStream extends PositionOutputStream {
     try {
       compressionType.finalize(compressionFilter);
       if (multiPartUpload == null && buffer.hasRemaining()) {
+        ObjectMetadata metadata = newObjectMetadata();
+        metadata.setContentLength(buffer.position());
         PutObjectRequest req = new PutObjectRequest(bucket, key,
-                new ByteArrayInputStream(buffer.array(), 0, buffer.position()), newObjectMetadata())
+                new ByteArrayInputStream(buffer.array(), 0, buffer.position()), metadata)
                 .withCannedAcl(cannedAcl);
         if (sseCustomerKey != null) {
           req.withSSECustomerKey(sseCustomerKey);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -168,8 +168,10 @@ public class S3OutputStream extends PositionOutputStream {
       if (multiPartUpload == null && buffer.hasRemaining()) {
         PutObjectRequest req = new PutObjectRequest(bucket, key,
                 new ByteArrayInputStream(buffer.array(), 0, buffer.position()), newObjectMetadata())
-                .withSSECustomerKey(sseCustomerKey)
                 .withCannedAcl(cannedAcl);
+        if (sseCustomerKey != null) {
+          req.withSSECustomerKey(sseCustomerKey);
+        }
         handleAmazonExceptions(() -> s3.putObject(req));
       } else if (buffer.hasRemaining()) {
         uploadPart(buffer.position());

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.4</version>
+        <version>11.0.11</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -49,7 +49,7 @@
     <scm>
         <connection>scm:git:git://github.com/confluentinc/kafka-connect-storage-cloud.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-storage-cloud.git</developerConnection>
-        <url>https://github.com/confluentinc/kafka-connect-storage-cloud</url>
+        <url>http://github.com/confluentinc/kafka-connect-storage-cloud</url>
         <tag>v10.1.0</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.11</version>
+        <version>11.0.4</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -58,7 +58,7 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.11</version>
+        <version>11.0.4</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <scm>
         <connection>scm:git:git://github.com/confluentinc/kafka-connect-storage-cloud.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-storage-cloud.git</developerConnection>
-        <url>http://github.com/confluentinc/kafka-connect-storage-cloud</url>
+        <url>https://github.com/confluentinc/kafka-connect-storage-cloud</url>
         <tag>v10.1.0</tag>
     </scm>
 
@@ -58,7 +58,7 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.


### PR DESCRIPTION
## Problem
For small files, which are files that total size (i.e. the plugin decided to rotate) is less than `s3.part.size` there is no need to upload using multi-part as there is only one part. So we can simply upload it as a single object.

## Solution

For small files, as defined above upload single file, not multi-upload.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
