### PR TITLE
flush data on termiantion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Kafka Connect Connector for S3
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-storage-cloud.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-storage-cloud?ref=badge_shield)
-
 
 *kafka-connect-storage-cloud* is the repository for Confluent's [Kafka Connectors](http://kafka.apache.org/documentation.html#connect)
 designed to be used to copy data from Kafka into Amazon S3. 
@@ -11,34 +9,34 @@ Documentation for this connector can be found [here](http://docs.confluent.io/cu
 
 Blogpost for this connector can be found [here](https://www.confluent.io/blog/apache-kafka-to-amazon-s3-exactly-once).
 
-# Development
+# Build
 
-To build a development version you'll need a recent version of Kafka 
-as well as a set of upstream Confluent projects, which you'll have to build from their appropriate snapshot branch.
-See [the kafka-connect-storage-common FAQ](https://github.com/confluentinc/kafka-connect-storage-common/wiki/FAQ)
-for guidance on this process.
+Kafka Connect Storage Common modules use a few dependencies which we sometimes use SNAPSHOT versions of. We do this during the development of a new release in order to build and test against new features. If you want to build a development version, you may need to build and install these dependencies to your local Maven repository in order to build the connector:
 
-You can build *kafka-connect-storage-cloud* with Maven using the standard lifecycle phases.
+- **Kafka** - clone https://github.com/confluentinc/kafka/ and build with `./gradlew build -x test` & `./gradlew -PskipSigning=true publishToMavenLocal`
+- **Common** - clone https://github.com/confluentinc/common and build with `mvn install -DskipTests`
+- **Rest Utils** - clone https://github.com/confluentinc/rest-utils and build with `mvn install -DskipTests`
+- **Avro converter** - clone https://github.com/confluentinc/schema-registry and build with `mvn install -DskipTests`
 
-# Running Integration Tests
-Integration tests are run as part of `mvn install`; however one needs to first configure the environment variable`AWS_CREDENTIALS_PATH` to point to a json file path with following structure:
-```
-{
-    "aws_access_key_id": "<key>",
-    "aws_secret_access_key": "<secret>"
-}
-```
+Then, to build Kafka Connect Storage Common modules and make them available to storage sink connectors, do the same on the current repo:
+- **Kafka Connect Storage Common** - clone https://github.com/logzio/kafka-connect-storage-common and build with `mvn install -DskipTests -Dcheckstyle.skip=true`
 
-# Contribute
+# Packing
 
-- Source Code: https://github.com/confluentinc/kafka-connect-storage-cloud
-- Issue Tracker: https://github.com/confluentinc/kafka-connect-storage-cloud/issues
-- Learn how to work with the connector's source code by reading our [Development and Contribution guidelines](CONTRIBUTING.md).
+In order to publish a docker image for a connector using this repository,
+you need to pack the code into a fat jar.
+To do this, run the following command:
 
+`mvn clean package -Dcheckstyle.skip=true`
 
-# License
+# Publish
 
-This project is licensed under the [Confluent Community License](LICENSE).
+You can publish multiple connectors with different configurations, 
+In this guide we will take our `internal-archiver` connector as an example.
 
+1. Copy the jar from `kafka-connect-s3/target/kafka-connect-s3-<version>-jar-with-dependencies.jar` to replace current jar in the [docker image](https://github.com/logzio/docker-additional/tree/master/external-images/logzio-internal-archiver).
+2. Create a new tag for the docker image with the new version by changing [this](https://github.com/logzio/docker-additional/blob/master/external-images/logzio-internal-archiver/build.bash#L3) version.
+3. Push the new tag to the docker registry by running [./build.bash](https://github.com/logzio/docker-additional/blob/master/external-images/logzio-internal-archiver/build.bash#L3).
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-storage-cloud.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fconfluentinc%2Fkafka-connect-storage-cloud?ref=badge_large)
+> [!WARNING]  
+> Make sure to update the version in the [build.bash](https://github.com/logzio/docker-additional/blob/master/external-images/logzio-internal-archiver/build.bash#L3) file before running it, because it can override the current image.

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -328,14 +328,14 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void close(Collection<TopicPartition> partitions) {
-    for (TopicPartition tp : topicPartitionWriters.keySet()) {
+    for (TopicPartition tp : partitions) {
       try {
         topicPartitionWriters.get(tp).close();
       } catch (ConnectException e) {
         log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
       }
+      topicPartitionWriters.remove(tp);
     }
-    topicPartitionWriters.clear();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -341,12 +341,14 @@ public class S3SinkTask extends SinkTask {
   @Override
   public void close(Collection<TopicPartition> partitions) {
     for (TopicPartition tp : partitions) {
-      try {
-        topicPartitionWriters.get(tp).close();
-      } catch (ConnectException e) {
-        log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
+      if (topicPartitionWriters.containsKey(tp)) {
+        try {
+          topicPartitionWriters.get(tp).close();
+        } catch (ConnectException e) {
+          log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
+        }
+        topicPartitionWriters.remove(tp);
       }
-      topicPartitionWriters.remove(tp);
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -651,7 +651,7 @@ public class TopicPartitionWriter {
     }
   }
 
-  private void commitFiles() {
+  protected void commitFiles() {
     for (Map.Entry<String, String> entry : commitFiles.entrySet()) {
       String encodedPartition = entry.getKey();
       commitFile(encodedPartition);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/hooks/BlockingKafkaPostCommitHook.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/hooks/BlockingKafkaPostCommitHook.java
@@ -49,20 +49,8 @@ public class BlockingKafkaPostCommitHook implements PostCommitHook {
 
   @Override
   public void init(S3SinkConnectorConfig config) {
-    @SuppressWarnings("unchecked")
-    Class<? extends Partitioner<?>> partitionerClass =
-            (Class<? extends Partitioner<?>>) config.getClass(
-                    PartitionerConfig.PARTITIONER_CLASS_CONFIG);
-
-    if (partitionerClass == null || !partitionerClass.getName().equals(
-            "io.logz.kafka.connect.FieldAndTimeBasedPartitioner")) {
-      throw new IllegalArgumentException("This post commit hook can be used ony with"
-              + " io.logz.kafka.connect.FieldAndTimeBasedPartitioner partitioner");
-    }
-
     String topicsDir = config.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     pattern = Pattern.compile(topicsDir + "/(\\d+)/");
-
     kafkaTopic = config.getPostCommitKafkaTopic();
     kafkaProducer = newKafkaPostCommitProducer(config);
     log.info("BlockingKafkaPostCommitHook initialized successfully");


### PR DESCRIPTION
## Problem

Since moving to use spots in internal-archiver we’re more vulnarable to high latencies due to spot interruptions. Currently, if there’s latency of more ~4 hours a wake up alert is triggered. We would like to minimize the impact of the spot interruptions as part of this epic.

[Jira ticket](https://logzio.atlassian.net/browse/CORE-1195)

## Solution

Flush current commit offset in case of spot interruption

## Overview

The connector's task has several functions triggered at different times:

1. **`preCommit`**: This function is triggered by the cluster before committing Kafka offsets. It returns the Kafka offsets to be committed. The cluster performs the commit if the offset has advanced. Offsets advance only after data is written to S3, which currently happens every 40 minutes.

2. **`close`**: This function is triggered when partitions are revoked from the connector's task. It can be called multiple times.

3. **`stop`**: This function is triggered when the task shuts down.

In our case, Kafka Connect triggers several main flows: 

1. **Periodic flow**: Kafka Connect periodically triggers `preCommit` and preforms a `commit`.

2. **Application shutdown**: When the application shuts down, the sequence is `preCommit`, `commit`, `close`, and `stop`.

3. **Partitions revoke**: When partitions are revoked, the sequence is `preCommit`, `commit`, and `close`.

## Implementation details

As observed, `close` and `stop` are called **after** the last commit of the application shutdown flow and the partition revoke flow.  
Therefore, it's crucial to integrate with `preCommit`, identify that we are in flow 2 or 3, and perform a `flush` to trigger the commit.

### How can we determine the current flow within `preCommit`?

- **Application Shutdown**: During shutdown, we can capture an `onShutdown` event, marking that the application is in the process of closing.

- **Partition Detachment**: In `preCommit`, a list of partitions to be revoked is passed. This is because only those partitions need to be committed. In any other situation, a list of all partitions connected to the task is passed. Since the task maintains a list of connected partitions, we can identify if a partition (or partitions) is being revoked by comparing the size of the list passed in `preCommit` to the existing list. If the list is smaller, a revoke is occurring.

## Results

<img width="1116" alt="Screenshot 2025-01-01 at 9 37 23" src="https://github.com/user-attachments/assets/e54e98aa-841c-4f22-b4aa-f98155205e60" />
