### PR TITLE
fix offset reset to 0 when commiting empty files

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -652,6 +652,11 @@ public class TopicPartitionWriter {
   }
 
   protected void commitFiles() {
+    if (currentOffset == -1) {
+      log.debug("No records to commit for {}", tp);
+      return;
+    }
+
     for (Map.Entry<String, String> entry : commitFiles.entrySet()) {
       String encodedPartition = entry.getKey();
       commitFile(encodedPartition);


### PR DESCRIPTION
### Bug Description

`currentOffset` is initiate to `-1` ([ref](https://github.com/logzio/kafka-connect-storage-cloud/blob/f6700eadcf68a3b8d9efbef0e1f1253c48c4c842/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java#L191)) and changes to the actual `currentOffset` after the first record consumed ([ref](https://github.com/logzio/kafka-connect-storage-cloud/blob/f6700eadcf68a3b8d9efbef0e1f1253c48c4c842/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java#L614)). 
When flushing files into s3 the `offsetToCommit` is assigned to be `currentOffset + 1` ([ref](https://github.com/logzio/kafka-connect-storage-cloud/blob/f6700eadcf68a3b8d9efbef0e1f1253c48c4c842/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java#L684)).
Once we initiate a s3 flush on an empty file, the `currentOffset` is `-1` and `offsetToCommit` assigned to be `-1 + 1 = 0`, then Kafka reset the offset to 0 although we should do nothing and keeps the offset as is.

### Solution

Prevent flushing to s3 when file is empty (`currentOffset == -1`)